### PR TITLE
feat: implement tokenfactory keeper logic

### DIFF
--- a/x/tokenfactory/keeper/msg_server_burn.go
+++ b/x/tokenfactory/keeper/msg_server_burn.go
@@ -4,15 +4,35 @@ import (
 	"context"
 
 	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/you/nuahchain/x/tokenfactory/types"
 )
 
-func (k msgServer) Burn(ctx context.Context, msg *types.MsgBurn) (*types.MsgBurnResponse, error) {
-	if _, err := k.addressCodec.StringToBytes(msg.Owner); err != nil {
+func (k msgServer) Burn(goCtx context.Context, msg *types.MsgBurn) (*types.MsgBurnResponse, error) {
+	admin, err := k.addressCodec.StringToBytes(msg.Owner)
+	if err != nil {
 		return nil, errorsmod.Wrap(err, "invalid authority address")
 	}
 
-	// TODO: Handle the message
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	if err := k.MustBeAdmin(ctx, msg.Denom, admin); err != nil {
+		return nil, err
+	}
+
+	if msg.Amount <= 0 {
+		return nil, types.ErrInvalidAmount
+	}
+
+	coins := sdk.NewCoins(sdk.NewCoin(msg.Denom, sdk.NewInt(msg.Amount)))
+	adminAddr := sdk.AccAddress(admin)
+
+	if err := k.bankKeeper.SendCoinsFromAccountToModule(ctx, adminAddr, types.ModuleAccountName, coins); err != nil {
+		return nil, err
+	}
+	if err := k.bankKeeper.BurnCoins(ctx, types.ModuleAccountName, coins); err != nil {
+		return nil, err
+	}
 
 	return &types.MsgBurnResponse{}, nil
 }

--- a/x/tokenfactory/keeper/msg_server_change_admin.go
+++ b/x/tokenfactory/keeper/msg_server_change_admin.go
@@ -4,15 +4,30 @@ import (
 	"context"
 
 	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/you/nuahchain/x/tokenfactory/types"
 )
 
-func (k msgServer) ChangeAdmin(ctx context.Context, msg *types.MsgChangeAdmin) (*types.MsgChangeAdminResponse, error) {
-	if _, err := k.addressCodec.StringToBytes(msg.Owner); err != nil {
+func (k msgServer) ChangeAdmin(goCtx context.Context, msg *types.MsgChangeAdmin) (*types.MsgChangeAdminResponse, error) {
+	admin, err := k.addressCodec.StringToBytes(msg.Owner)
+	if err != nil {
 		return nil, errorsmod.Wrap(err, "invalid authority address")
 	}
 
-	// TODO: Handle the message
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	if err := k.MustBeAdmin(ctx, msg.Denom, admin); err != nil {
+		return nil, err
+	}
+
+	newAdmin, err := k.addressCodec.StringToBytes(msg.NewAdmin)
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "invalid new admin address")
+	}
+
+	d, _ := k.GetDenom(ctx, msg.Denom)
+	d.Owner = sdk.AccAddress(newAdmin).String()
+	k.SetDenom(ctx, d)
 
 	return &types.MsgChangeAdminResponse{}, nil
 }

--- a/x/tokenfactory/keeper/msg_server_denom_test.go
+++ b/x/tokenfactory/keeper/msg_server_denom_test.go
@@ -23,7 +23,7 @@ func TestDenomMsgServerCreate(t *testing.T) {
 		}
 		_, err := srv.CreateDenom(f.ctx, expected)
 		require.NoError(t, err)
-		rst, err := f.keeper.Denom.Get(f.ctx, expected.Denom)
+		rst, err := f.keeper.Denom.Get(f.ctx, f.keeper.FullDenom(expected.Owner, expected.Denom))
 		require.NoError(t, err)
 		require.Equal(t, expected.Owner, rst.Owner)
 	}
@@ -85,7 +85,7 @@ func TestDenomMsgServerUpdate(t *testing.T) {
 				require.ErrorIs(t, err, tc.err)
 			} else {
 				require.NoError(t, err)
-				rst, err := f.keeper.Denom.Get(f.ctx, expected.Denom)
+				rst, err := f.keeper.Denom.Get(f.ctx, f.keeper.FullDenom(expected.Owner, expected.Denom))
 				require.NoError(t, err)
 				require.Equal(t, expected.Owner, rst.Owner)
 			}
@@ -148,7 +148,8 @@ func TestDenomMsgServerDelete(t *testing.T) {
 				require.ErrorIs(t, err, tc.err)
 			} else {
 				require.NoError(t, err)
-				found, err := f.keeper.Denom.Has(f.ctx, tc.request.Denom)
+				full := f.keeper.FullDenom(tc.request.Owner, tc.request.Denom)
+				found, err := f.keeper.Denom.Has(f.ctx, full)
 				require.NoError(t, err)
 				require.False(t, found)
 			}

--- a/x/tokenfactory/keeper/msg_server_mint.go
+++ b/x/tokenfactory/keeper/msg_server_mint.go
@@ -4,15 +4,40 @@ import (
 	"context"
 
 	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/you/nuahchain/x/tokenfactory/types"
 )
 
-func (k msgServer) Mint(ctx context.Context, msg *types.MsgMint) (*types.MsgMintResponse, error) {
-	if _, err := k.addressCodec.StringToBytes(msg.Owner); err != nil {
+func (k msgServer) Mint(goCtx context.Context, msg *types.MsgMint) (*types.MsgMintResponse, error) {
+	admin, err := k.addressCodec.StringToBytes(msg.Owner)
+	if err != nil {
 		return nil, errorsmod.Wrap(err, "invalid authority address")
 	}
 
-	// TODO: Handle the message
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	if err := k.MustBeAdmin(ctx, msg.Denom, admin); err != nil {
+		return nil, err
+	}
+
+	if msg.Amount <= 0 {
+		return nil, types.ErrInvalidAmount
+	}
+
+	recipientAddr, err := k.addressCodec.StringToBytes(msg.Recipient)
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "invalid recipient address")
+	}
+
+	coins := sdk.NewCoins(sdk.NewCoin(msg.Denom, sdk.NewInt(msg.Amount)))
+
+	if err := k.bankKeeper.MintCoins(ctx, types.ModuleAccountName, coins); err != nil {
+		return nil, err
+	}
+
+	if err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleAccountName, sdk.AccAddress(recipientAddr), coins); err != nil {
+		return nil, err
+	}
 
 	return &types.MsgMintResponse{}, nil
 }

--- a/x/tokenfactory/keeper/msg_server_set_denom_metadata.go
+++ b/x/tokenfactory/keeper/msg_server_set_denom_metadata.go
@@ -2,17 +2,54 @@ package keeper
 
 import (
 	"context"
+	"encoding/json"
 
 	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
 	"github.com/you/nuahchain/x/tokenfactory/types"
 )
 
-func (k msgServer) SetDenomMetadata(ctx context.Context, msg *types.MsgSetDenomMetadata) (*types.MsgSetDenomMetadataResponse, error) {
-	if _, err := k.addressCodec.StringToBytes(msg.Owner); err != nil {
+type denomUnitJSON struct {
+	Denom    string   `json:"denom"`
+	Exponent uint32   `json:"exponent"`
+	Aliases  []string `json:"aliases"`
+}
+
+func (k msgServer) SetDenomMetadata(goCtx context.Context, msg *types.MsgSetDenomMetadata) (*types.MsgSetDenomMetadataResponse, error) {
+	admin, err := k.addressCodec.StringToBytes(msg.Owner)
+	if err != nil {
 		return nil, errorsmod.Wrap(err, "invalid authority address")
 	}
 
-	// TODO: Handle the message
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	if err := k.MustBeAdmin(ctx, msg.Base, admin); err != nil {
+		return nil, err
+	}
+
+	var units []denomUnitJSON
+	if err := json.Unmarshal([]byte(msg.DenomUnits), &units); err != nil {
+		return nil, errorsmod.Wrap(err, "invalid denomUnits json")
+	}
+
+	bu := make([]*banktypes.DenomUnit, 0, len(units))
+	for _, u := range units {
+		bu = append(bu, &banktypes.DenomUnit{Denom: u.Denom, Exponent: u.Exponent, Aliases: u.Aliases})
+	}
+
+	md := banktypes.Metadata{
+		Base:        msg.Base,
+		Name:        msg.Name,
+		Symbol:      msg.Symbol,
+		Display:     msg.Display,
+		DenomUnits:  bu,
+		Description: msg.Description,
+	}
+
+	if err := k.bankKeeper.SetDenomMetaData(ctx, md); err != nil {
+		return nil, err
+	}
 
 	return &types.MsgSetDenomMetadataResponse{}, nil
 }

--- a/x/tokenfactory/types/errors.go
+++ b/x/tokenfactory/types/errors.go
@@ -3,10 +3,14 @@ package types
 // DONTCOVER
 
 import (
-	"cosmossdk.io/errors"
+	errorsmod "cosmossdk.io/errors"
 )
 
 // x/tokenfactory module sentinel errors
 var (
-	ErrInvalidSigner = errors.Register(ModuleName, 1100, "expected gov account as only signer for proposal message")
+	ErrInvalidSigner   = errorsmod.Register(ModuleName, 1100, "expected gov account as only signer for proposal message")
+	ErrDenomExists     = errorsmod.Register(ModuleName, 2, "denom already exists")
+	ErrInvalidSubdenom = errorsmod.Register(ModuleName, 3, "invalid subdenom")
+	ErrNotAdmin        = errorsmod.Register(ModuleName, 4, "caller is not denom admin")
+	ErrInvalidAmount   = errorsmod.Register(ModuleName, 5, "invalid amount")
 )

--- a/x/tokenfactory/types/expected_keepers.go
+++ b/x/tokenfactory/types/expected_keepers.go
@@ -5,6 +5,7 @@ import (
 
 	"cosmossdk.io/core/address"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
 // AuthKeeper defines the expected interface for the Auth module.
@@ -17,7 +18,11 @@ type AuthKeeper interface {
 // BankKeeper defines the expected interface for the Bank module.
 type BankKeeper interface {
 	SpendableCoins(context.Context, sdk.AccAddress) sdk.Coins
-	// Methods imported from bank should be defined here
+	MintCoins(context.Context, string, sdk.Coins) error
+	BurnCoins(context.Context, string, sdk.Coins) error
+	SendCoinsFromModuleToAccount(context.Context, string, sdk.AccAddress, sdk.Coins) error
+	SendCoinsFromAccountToModule(context.Context, sdk.AccAddress, string, sdk.Coins) error
+	SetDenomMetaData(context.Context, banktypes.Metadata) error
 }
 
 // ParamSubspace defines the expected Subspace interface for parameters.

--- a/x/tokenfactory/types/keys.go
+++ b/x/tokenfactory/types/keys.go
@@ -9,6 +9,15 @@ const (
 	// StoreKey defines the primary module store key
 	StoreKey = ModuleName
 
+	// RouterKey defines the module's message routing key
+	RouterKey = ModuleName
+
+	// MemStoreKey defines the in-memory store key
+	MemStoreKey = "mem_tokenfactory"
+
+	// ModuleAccountName defines the module account name
+	ModuleAccountName = ModuleName
+
 	// GovModuleName duplicates the gov module's name to avoid a dependency with x/gov.
 	// It should be synced with the gov module's name if it is ever changed.
 	// See: https://github.com/cosmos/cosmos-sdk/blob/v0.52.0-beta.2/x/gov/types/keys.go#L9


### PR DESCRIPTION
## Summary
- add module constants and custom errors for tokenfactory
- implement keeper helpers and message handlers for mint, burn, admin changes, and metadata

## Testing
- `go test ./x/tokenfactory/...` *(fails: command hung in container)*

------
https://chatgpt.com/codex/tasks/task_e_68b39f3729848326b8b1c94edcd466d8