### PR TITLE
chore: provide kv store service in root cmd

### DIFF
--- a/cmd/nuahchaind/cmd/root.go
+++ b/cmd/nuahchaind/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/config"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/auth/tx"
@@ -33,6 +34,7 @@ func NewRootCmd() *cobra.Command {
 			depinject.Supply(log.NewNopLogger()),
 			depinject.Provide(
 				ProvideClientContext,
+				runtime.ProvideKVStoreService,
 			),
 		),
 		&autoCliOpts,


### PR DESCRIPTION
## Summary
- provide runtime.KVStoreService to root command's dependency injection

## Testing
- `go build ./cmd/nuahchaind` *(fails: command did not complete in provided time)*
- `go test ./...` *(fails: command did not complete in provided time)*

------
https://chatgpt.com/codex/tasks/task_e_68b41ac70ee083269a848237d1e4284c