### PR TITLE
fix: add BankKeeper dependency injection

### DIFF
--- a/x/tokenfactory/keeper/msg_server_set_denom_metadata.go
+++ b/x/tokenfactory/keeper/msg_server_set_denom_metadata.go
@@ -47,9 +47,7 @@ func (k msgServer) SetDenomMetadata(goCtx context.Context, msg *types.MsgSetDeno
 		Description: msg.Description,
 	}
 
-	if err := k.bankKeeper.SetDenomMetaData(ctx, md); err != nil {
-		return nil, err
-	}
+	k.bankKeeper.SetDenomMetaData(ctx, md)
 
 	return &types.MsgSetDenomMetadataResponse{}, nil
 }

--- a/x/tokenfactory/module/depinject.go
+++ b/x/tokenfactory/module/depinject.go
@@ -8,6 +8,7 @@ import (
 	"cosmossdk.io/depinject/appconfig"
 	"github.com/cosmos/cosmos-sdk/codec"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 
 	"github.com/you/nuahchain/x/tokenfactory/keeper"
 	"github.com/you/nuahchain/x/tokenfactory/types"
@@ -34,7 +35,7 @@ type ModuleInputs struct {
 	AddressCodec address.Codec
 
 	AuthKeeper types.AuthKeeper
-	BankKeeper types.BankKeeper
+	BankKeeper bankkeeper.BaseKeeper
 }
 
 type ModuleOutputs struct {

--- a/x/tokenfactory/types/expected_keepers.go
+++ b/x/tokenfactory/types/expected_keepers.go
@@ -22,7 +22,7 @@ type BankKeeper interface {
 	BurnCoins(context.Context, string, sdk.Coins) error
 	SendCoinsFromModuleToAccount(context.Context, string, sdk.AccAddress, sdk.Coins) error
 	SendCoinsFromAccountToModule(context.Context, sdk.AccAddress, string, sdk.Coins) error
-	SetDenomMetaData(context.Context, banktypes.Metadata) error
+	SetDenomMetaData(context.Context, banktypes.Metadata)
 }
 
 // ParamSubspace defines the expected Subspace interface for parameters.


### PR DESCRIPTION
## Summary
- inject bank BaseKeeper into tokenfactory module
- align BankKeeper interface with sdk
- remove unused error handling in metadata message

## Testing
- `go test ./x/tokenfactory/...` (fails: unauthorized test)

------
https://chatgpt.com/codex/tasks/task_e_68b433b9be188326888675ccb899732a